### PR TITLE
Node.js 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 25
+          node-version-file: 'package.json'
           check-latest: true
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 25
+          node-version-file: 'package.json'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 25
+          node-version-file: 'package.json'
           check-latest: true
       - name: Remove label
         if: github.event_name == 'pull_request'

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -278,29 +278,14 @@ export default defineConfig([
       // https://www.eslint-react.xyz/docs/rules/overview
       /*
 // copy all the rules from the rules table for easy pasting
-function getRules(id) {
-  return (
-    Iterator.from(
-      document
-        // select rules table
-        .querySelector(`#${id} ~ *:has(table) > table`)
-        // select all rule links
-        .querySelectorAll('tr a')
-    )
-      // map link to rule declaration
-      .map((a) => `'@eslint-react/${a.pathname.slice(a.pathname.lastIndexOf('/') + 1)}': 1,`)
-  );
-}
 copy(
-  Iterator.from([
-    getRules('x-rules'),
-    getRules('jsx-rules'),
-    getRules('rsc-rules'),
-    getRules('dom-rules'),
-    getRules('web-api-rules'),
-    getRules('naming-convention-rules'),
-  ])
-    .flatMap((x) => x)
+  Iterator.from(
+    document
+      // select all non-debug rule links
+      .querySelectorAll('tr a:not([href*="rules/debug"])')
+  )
+    // map link to rule declaration
+    .map((a) => `'@eslint-react/${a.pathname.slice(a.pathname.lastIndexOf('/') + 1)}': 1,`)
     .toArray()
     .join('\n')
 );

--- a/package.json
+++ b/package.json
@@ -83,5 +83,12 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^26.0.0",
+      "onFail": "warn"
+    }
   }
 }

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -177,12 +177,10 @@ export function useCalculatedColumns<R, SR>({
       let width = getColumnWidth(column);
 
       if (typeof width === 'number') {
-        // eslint-disable-next-line @eslint-react/use-memo
         width = clampColumnWidth(width, column);
       } else {
         // This is a placeholder width so we can continue to use virtualization.
         // The actual value is set after the column is rendered
-        // eslint-disable-next-line @eslint-react/use-memo
         width = column.minWidth;
       }
       templateColumns.push(`${width}px`);


### PR DESCRIPTION
- https://nodejs.org/en/blog/release/v26.0.0
- configured `devEngines` in `package.json`
  - Node.js version is now configured in a singular place
  - https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines
  - https://github.com/openjs-foundation/package-metadata-interoperability-working-group/blob/main/devengines-field-proposal.md
  - the `setup-node` action [added support for it 2 months ago](https://github.com/actions/setup-node/releases)
    - https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file