### PR TITLE
support dynamic height rows for non-virtualized rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ function MyGrid() {
 
 Function to generate unique IDs for group rows. If not provided, a default implementation is used that concatenates parent and group keys with `__`.
 
-###### `rowHeight?: Maybe<number | ((args: RowHeightArgs<R>) => number)>`
+###### `rowHeight?: Maybe<number | string | ((args: RowHeightArgs<R>) => number)>`
 
 **Note:** Unlike `DataGrid`, the `rowHeight` function receives [`RowHeightArgs<R>`](#rowheightargstrow) which includes a `type` property to distinguish between regular rows and group rows:
 

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -462,13 +462,17 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     getRowHeight,
     findRowIdx
   } = useViewportRows({
-    element: gridRef.current,
     rows,
-    rowHeight,
     clientHeight,
     scrollTop,
     enableVirtualization,
-    gridHeight
+    ...(typeof rowHeight === 'string'
+      ? {
+          rowHeight,
+          element: gridRef.current,
+          gridHeight
+        }
+      : { rowHeight })
   });
 
   const {

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import type { Key, KeyboardEvent } from 'react';
+import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 
 import {
+  type ActivePosition,
   HeaderRowSelectionChangeContext,
   HeaderRowSelectionContext,
+  type HeaderRowSelectionContextValue,
+  type PartialPosition,
   RowSelectionChangeContext,
   useActivePosition,
   useCalculatedColumns,
@@ -14,10 +17,7 @@ import {
   useScrollState,
   useScrollToPosition,
   useViewportColumns,
-  useViewportRows,
-  type ActivePosition,
-  type HeaderRowSelectionContextValue,
-  type PartialPosition
+  useViewportRows
 } from './hooks';
 import {
   assertIsValidKeyGetter,
@@ -45,7 +45,6 @@ import type {
   CellMouseEventHandler,
   CellNavigationMode,
   CellPasteArgs,
-  PositionChangeArgs,
   Column,
   ColumnOrColumnGroup,
   ColumnWidths,
@@ -53,11 +52,12 @@ import type {
   FillEvent,
   Maybe,
   Position,
+  PositionChangeArgs,
   Renderers,
   RowsChangeData,
-  SetActivePositionOptions,
   SelectHeaderRowEvent,
   SelectRowEvent,
+  SetActivePositionOptions,
   SortColumn
 } from './types';
 import { defaultRenderCell } from './Cell';
@@ -138,7 +138,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * Height of each row in pixels
    * @default 35
    */
-  rowHeight?: Maybe<number | ((row: NoInfer<R>) => number)>;
+  rowHeight?: Maybe<number | string | ((row: NoInfer<R>) => number)>;
   /**
    * Height of the header row in pixels
    * @default 35
@@ -303,8 +303,12 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const renderCheckbox =
     renderers?.renderCheckbox ?? defaultRenderers?.renderCheckbox ?? defaultRenderCheckbox;
   const noRowsFallback = renderers?.noRowsFallback ?? defaultRenderers?.noRowsFallback;
-  const enableVirtualization = rawEnableVirtualization ?? true;
+  const enableVirtualization = rawEnableVirtualization ?? typeof rawRowHeight !== 'string';
   const direction = rawDirection ?? 'ltr';
+
+  if (enableVirtualization && typeof rowHeight === 'string') {
+    throw new Error('`rowHeight` cannot be a string when `enableVirtualization` is true.');
+  }
 
   /**
    * ref
@@ -413,7 +417,9 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     maxRowIdx,
     setDraggedOverRowIdx
   });
-  const { setScrollToPosition, scrollToPositionElement } = useScrollToPosition({ gridRef });
+  const { setScrollToPosition, scrollToPositionElement } = useScrollToPosition({
+    gridRef
+  });
 
   const defaultGridComponents = useMemo(
     () => ({
@@ -456,11 +462,13 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     getRowHeight,
     findRowIdx
   } = useViewportRows({
+    element: gridRef.current,
     rows,
     rowHeight,
     clientHeight,
     scrollTop,
-    enableVirtualization
+    enableVirtualization,
+    gridHeight
   });
 
   const {
@@ -690,7 +698,11 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     if (isSelectable && shiftKey && key === ' ') {
       assertIsValidKeyGetter<R, K>(rowKeyGetter);
       const rowKey = rowKeyGetter(row);
-      selectRow({ row, checked: !selectedRows.has(rowKey), isShiftClick: false });
+      selectRow({
+        row,
+        checked: !selectedRows.has(rowKey),
+        isShiftClick: false
+      });
       // prevent scrolling
       event.preventDefault();
       return;
@@ -776,7 +788,11 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     const indexes: number[] = [];
     for (let i = startRowIdx; i < endRowIdx; i++) {
       if (isCellEditable({ rowIdx: i, idx })) {
-        const updatedRow = onFill!({ columnKey: column.key, sourceRow, targetRow: rows[i] });
+        const updatedRow = onFill!({
+          columnKey: column.key,
+          sourceRow,
+          targetRow: rows[i]
+        });
         if (updatedRow !== rows[i]) {
           updatedRows[i] = updatedRow;
           indexes.push(i);
@@ -1048,7 +1064,11 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     });
 
     function closeEditor(shouldFocus: boolean) {
-      const newPosition: ActivePosition = { idx: activePosition.idx, rowIdx, mode: 'ACTIVE' };
+      const newPosition: ActivePosition = {
+        idx: activePosition.idx,
+        rowIdx,
+        mode: 'ACTIVE'
+      };
       setActivePosition(newPosition);
       if (shouldFocus) {
         setPositionToFocus(newPosition);

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -469,7 +469,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     ...(typeof rowHeight === 'string'
       ? {
           rowHeight,
-          element: gridRef.current,
+          gridRef,
           gridHeight
         }
       : { rowHeight })

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type RefObject } from 'react';
 
 import { floor, max, min } from '../utils';
 
@@ -12,7 +12,7 @@ interface ViewportRowsBaseArgs<R> {
 
 interface ViewportRowsArgsStringHeight {
   rowHeight: string;
-  element: HTMLElement | null;
+  gridRef: RefObject<HTMLDivElement | null>;
   gridHeight: number;
 }
 
@@ -31,6 +31,7 @@ export function useViewportRows<R>({
   enableVirtualization,
   ...rest
 }: ViewportRowsArgs<R>) {
+  const { gridRef, gridHeight } = rest as Partial<ViewportRowsArgsStringHeight>;
   const { totalRowHeight, gridTemplateRows, getRowTop, getRowHeight, findRowIdx } = useMemo(() => {
     if (typeof rowHeight === 'number') {
       return {
@@ -43,7 +44,6 @@ export function useViewportRows<R>({
     }
 
     if (typeof rowHeight === 'string') {
-      const { element, gridHeight } = rest as ViewportRowsArgsStringHeight;
       if (!gridHeight) {
         throw new Error(
           'props.gridHeight is required when rowHeight is a string. This is needed to calculate the total height of the rows.'
@@ -62,21 +62,24 @@ export function useViewportRows<R>({
       };
 
       return {
-        totalRowHeight: gridHeight ?? 0,
+        totalRowHeight: gridHeight,
         gridTemplateRows: ` repeat(${rows.length}, ${rowHeight})`,
         getRowTop(rowIdx: number) {
+          const element = gridRef?.current;
           if (!element) return -1;
           const cell = getRowElementFirstCell(element, rowIdx);
           if (!cell) return -1;
           return cell.getBoundingClientRect().top + element.scrollTop;
         },
         getRowHeight(rowIdx: number) {
+          const element = gridRef?.current;
           if (!element) return -1;
           const cell = getRowElementFirstCell(element, rowIdx);
           if (!cell) return -1;
           return cell.clientHeight;
         },
         findRowIdx(offset: number) {
+          const element = gridRef?.current;
           if (!element) return -1;
           let start = 0;
           let end = rows.length - 1;
@@ -176,15 +179,21 @@ export function useViewportRows<R>({
         return 0;
       }
     };
-  }, [rowHeight, rows]);
+  }, [rowHeight, rows, gridRef, gridHeight]);
 
   let rowOverscanStartIdx = 0;
   let rowOverscanEndIdx = rows.length - 1;
 
   if (enableVirtualization) {
     const overscanThreshold = 4;
+    // `findRowIdx` only reads `gridRef.current` in the string-rowHeight branch,
+    // which is unreachable here because `enableVirtualization` is forced off when
+    // `rowHeight` is a string (see DataGrid.tsx).
+    /* eslint-disable react-hooks/refs */
     const rowVisibleStartIdx = findRowIdx(scrollTop);
     const rowVisibleEndIdx = findRowIdx(scrollTop + clientHeight);
+    /* eslint-enable react-hooks/refs */
+
     rowOverscanStartIdx = max(0, rowVisibleStartIdx - overscanThreshold);
     rowOverscanEndIdx = min(rows.length - 1, rowVisibleEndIdx + overscanThreshold);
   }

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -3,19 +3,23 @@ import { useMemo } from 'react';
 import { floor, max, min } from '../utils';
 
 interface ViewportRowsArgs<R> {
+  element: HTMLElement | null;
   rows: readonly R[];
-  rowHeight: number | ((row: R) => number);
+  rowHeight: number | string | ((row: R) => number);
   clientHeight: number;
   scrollTop: number;
   enableVirtualization: boolean;
+  gridHeight: number;
 }
 
 export function useViewportRows<R>({
+  element,
   rows,
   rowHeight,
   clientHeight,
   scrollTop,
-  enableVirtualization
+  enableVirtualization,
+  gridHeight
 }: ViewportRowsArgs<R>) {
   const { totalRowHeight, gridTemplateRows, getRowTop, getRowHeight, findRowIdx } = useMemo(() => {
     if (typeof rowHeight === 'number') {
@@ -25,6 +29,57 @@ export function useViewportRows<R>({
         getRowTop: (rowIdx: number) => rowIdx * rowHeight,
         getRowHeight: () => rowHeight,
         findRowIdx: (offset: number) => floor(offset / rowHeight)
+      };
+    }
+
+    if (typeof rowHeight === 'string') {
+      const getRowElementFirstCell = (element: Element, rowIdx: number): Element | null => {
+        const nth = element.querySelector('.rdg-header-row') ? rowIdx + 2 : rowIdx + 1;
+        return element.querySelector(`[role="row"][aria-rowindex="${nth}"] > [role="gridcell"]`);
+      };
+      const getRowYTop = (element: Element, rowIdx: number) => {
+        const cell = getRowElementFirstCell(element, rowIdx);
+        if (!cell) return -1;
+        return cell.getBoundingClientRect().top + element.scrollTop;
+      };
+      return {
+        totalRowHeight: gridHeight ?? 0,
+        gridTemplateRows: ` repeat(${rows.length}, ${rowHeight})`,
+        getRowTop(rowIdx: number) {
+          if (!element) return -1;
+          const cell = getRowElementFirstCell(element, rowIdx);
+          if (!cell) return -1;
+          return cell.getBoundingClientRect().top + element.scrollTop;
+        },
+        getRowHeight(rowIdx: number) {
+          if (!element) return -1;
+          const cell = getRowElementFirstCell(element, rowIdx);
+          if (!cell) return -1;
+          return cell.clientHeight;
+        },
+        findRowIdx(offset: number) {
+          if (!element) return -1;
+          let start = 0;
+          let end = rows.length - 1;
+
+          while (start <= end) {
+            const middle = start + floor((end - start) / 2);
+            const currentScrollTop = getRowYTop(element, middle);
+            const prevScrollTop = getRowYTop(element, middle - 1);
+
+            if (currentScrollTop >= offset && prevScrollTop < offset) return middle;
+
+            if (currentScrollTop < offset) {
+              start = middle + 1;
+            } else if (currentScrollTop > offset) {
+              end = middle - 1;
+            }
+
+            if (start > end) return end;
+          }
+
+          return -1;
+        }
       };
     }
 
@@ -102,7 +157,7 @@ export function useViewportRows<R>({
         return 0;
       }
     };
-  }, [rowHeight, rows]);
+  }, [element, gridHeight, rowHeight, rows]);
 
   let rowOverscanStartIdx = 0;
   let rowOverscanEndIdx = rows.length - 1;

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -7,6 +7,7 @@ interface ViewportRowsBaseArgs<R> {
   clientHeight: number;
   scrollTop: number;
   enableVirtualization: boolean;
+  gridHeight?: number;
 }
 
 interface ViewportRowsArgsStringHeight {
@@ -43,11 +44,6 @@ export function useViewportRows<R>({
 
     if (typeof rowHeight === 'string') {
       const { element, gridHeight } = rest as ViewportRowsArgsStringHeight;
-      if (!element) {
-        throw new Error(
-          'props.element is required when rowHeight is a string. This is needed to calculate the position of the rows.'
-        );
-      }
       if (!gridHeight) {
         throw new Error(
           'props.gridHeight is required when rowHeight is a string. This is needed to calculate the total height of the rows.'
@@ -180,7 +176,7 @@ export function useViewportRows<R>({
         return 0;
       }
     };
-  }, [element, gridHeight, rowHeight, rows]);
+  }, [rowHeight, rows]);
 
   let rowOverscanStartIdx = 0;
   let rowOverscanEndIdx = rows.length - 1;

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -2,24 +2,33 @@ import { useMemo } from 'react';
 
 import { floor, max, min } from '../utils';
 
-interface ViewportRowsArgs<R> {
-  element: HTMLElement | null;
+interface ViewportRowsBaseArgs<R> {
   rows: readonly R[];
-  rowHeight: number | string | ((row: R) => number);
   clientHeight: number;
   scrollTop: number;
   enableVirtualization: boolean;
+}
+
+interface ViewportRowsArgsStringHeight {
+  rowHeight: string;
+  element: HTMLElement | null;
   gridHeight: number;
 }
 
+interface ViewportRowsArgsRegularHeight<R> {
+  rowHeight: number | ((row: R) => number);
+}
+
+type ViewportRowsArgs<R> = ViewportRowsBaseArgs<R> &
+  (ViewportRowsArgsStringHeight | ViewportRowsArgsRegularHeight<R>);
+
 export function useViewportRows<R>({
-  element,
   rows,
   rowHeight,
   clientHeight,
   scrollTop,
   enableVirtualization,
-  gridHeight
+  ...rest
 }: ViewportRowsArgs<R>) {
   const { totalRowHeight, gridTemplateRows, getRowTop, getRowHeight, findRowIdx } = useMemo(() => {
     if (typeof rowHeight === 'number') {
@@ -33,15 +42,29 @@ export function useViewportRows<R>({
     }
 
     if (typeof rowHeight === 'string') {
+      const { element, gridHeight } = rest as ViewportRowsArgsStringHeight;
+      if (!element) {
+        throw new Error(
+          'props.element is required when rowHeight is a string. This is needed to calculate the position of the rows.'
+        );
+      }
+      if (!gridHeight) {
+        throw new Error(
+          'props.gridHeight is required when rowHeight is a string. This is needed to calculate the total height of the rows.'
+        );
+      }
+
       const getRowElementFirstCell = (element: Element, rowIdx: number): Element | null => {
         const nth = element.querySelector('.rdg-header-row') ? rowIdx + 2 : rowIdx + 1;
         return element.querySelector(`[role="row"][aria-rowindex="${nth}"] > [role="gridcell"]`);
       };
+
       const getRowYTop = (element: Element, rowIdx: number) => {
         const cell = getRowElementFirstCell(element, rowIdx);
         if (!cell) return -1;
         return cell.getBoundingClientRect().top + element.scrollTop;
       };
+
       return {
         totalRowHeight: gridHeight ?? 0,
         gridTemplateRows: ` repeat(${rows.length}, ${rowHeight})`,

--- a/test/browser/rowHeight.test.tsx
+++ b/test/browser/rowHeight.test.tsx
@@ -28,6 +28,14 @@ async function expectGridRows(rowHeightFn: (row: number) => number, expected: st
   expect(grid.element().style.gridTemplateRows).toBe(expected);
 }
 
+// Data rows are rendered with `aria-rowindex` starting at 2 (the header row is 1),
+// so the zero-based row index of the active cell is `aria-rowindex - 2`.
+function getActiveDataRowIdx() {
+  const cell = page.getActiveCell().element();
+  const row = cell.closest('[role="row"]')!;
+  return Number(row.getAttribute('aria-rowindex')) - 2;
+}
+
 test('rowHeight is number', async () => {
   await setupGrid(40);
 
@@ -164,4 +172,49 @@ test('rowHeight string + explicit enableVirtualization=true throws', async () =>
 
   // eslint-disable-next-line no-console
   vi.mocked(console.error).mockClear();
+});
+
+test('PageDown/PageUp navigate through string (auto) height rows', async () => {
+  const columns: Column<{ id: number; content: string }>[] = [
+    { key: 'id', name: 'ID', width: 80 },
+    {
+      key: 'content',
+      name: 'Content',
+      width: 200,
+      renderCell: ({ row }) => <div style={{ whiteSpace: 'pre' }}>{row.content}</div>
+    }
+  ];
+  // Multi-line content makes each auto-sized row tall, and the fixed grid height
+  // forces a scrollable viewport so paging moves through several rows at a time.
+  // This exercises the string-height getRowTop/getRowHeight/findRowIdx DOM paths,
+  // which measure the rendered cells rather than computing offsets from a number.
+  const rows = Array.from({ length: 50 }, (_, i) => ({
+    id: i,
+    content: `row ${i}\nline two\nline three`
+  }));
+
+  await setup({ columns, rows, rowHeight: 'auto', style: { blockSize: 300 } });
+
+  // tab into the grid (lands on the header row) then move onto the first data row
+  await safeTab();
+  await userEvent.keyboard('{arrowdown}');
+  expect(getActiveDataRowIdx()).toBe(0);
+
+  // PageDown moves the active cell forward through the measured rows
+  await userEvent.keyboard('{PageDown}');
+  const afterPageDown = getActiveDataRowIdx();
+  expect(afterPageDown).toBeGreaterThan(0);
+
+  // PageUp moves it back up
+  await userEvent.keyboard('{PageUp}');
+  const afterPageUp = getActiveDataRowIdx();
+  expect(afterPageUp).toBeLessThan(afterPageDown);
+
+  // and PageDown again moves forward from there
+  await userEvent.keyboard('{PageDown}');
+  expect(getActiveDataRowIdx()).toBeGreaterThan(afterPageUp);
+
+  // Ctrl+End reaches the last row with string heights
+  await userEvent.keyboard('{Control>}{end}{/Control}');
+  expect(getActiveDataRowIdx()).toBe(rows.length - 1);
 });

--- a/test/browser/rowHeight.test.tsx
+++ b/test/browser/rowHeight.test.tsx
@@ -150,6 +150,7 @@ test('rowHeight is "auto" sizes rows to fit their content', async () => {
 
 test('rowHeight string + explicit enableVirtualization=true throws', async () => {
   // Suppress React's error logging for this expected render error
+  // eslint-disable-next-line no-console
   vi.mocked(console.error).mockImplementation(() => {});
 
   await expect(
@@ -161,5 +162,6 @@ test('rowHeight string + explicit enableVirtualization=true throws', async () =>
     })
   ).rejects.toThrow('`rowHeight` cannot be a string when `enableVirtualization` is true.');
 
+  // eslint-disable-next-line no-console
   vi.mocked(console.error).mockClear();
 });

--- a/test/browser/rowHeight.test.tsx
+++ b/test/browser/rowHeight.test.tsx
@@ -102,3 +102,64 @@ test('rowHeight with unique first height', async () => {
     return row === 0 ? 45 : 50;
   }, 'repeat(1, 35px) 45px repeat(49, 50px)');
 });
+
+test('rowHeight is "auto" sets gridTemplateRows to repeat(N, auto)', async () => {
+  await setupGrid('auto');
+
+  expect(grid.element().style.gridTemplateRows).toBe('repeat(1, 35px) repeat(50, auto)');
+});
+
+test('rowHeight as a string auto-disables virtualization and renders all rows', async () => {
+  await setupGrid('auto');
+
+  // virtualization is off by default when `rowHeight` is a string,
+  // so every row is rendered regardless of viewport size
+  await testRowCount(50);
+});
+
+test('rowHeight accepts arbitrary CSS track values', async () => {
+  await setupGrid('min-content');
+
+  expect(grid.element().style.gridTemplateRows).toBe('repeat(1, 35px) repeat(50, min-content)');
+  await testRowCount(50);
+});
+
+test('rowHeight is "auto" sizes rows to fit their content', async () => {
+  const columns: Column<{ id: number; content: string }>[] = [
+    { key: 'id', name: 'ID', width: 80 },
+    {
+      key: 'content',
+      name: 'Content',
+      width: 200,
+      renderCell: ({ row }) => <div style={{ whiteSpace: 'pre' }}>{row.content}</div>
+    }
+  ];
+  const rows = [
+    { id: 0, content: 'short' },
+    { id: 1, content: 'line one\nline two\nline three\nline four' }
+  ];
+
+  await setup({ columns, rows, rowHeight: 'auto' });
+
+  const row0 = page.getRow().nth(0).element() as HTMLElement;
+  const row1 = page.getRow().nth(1).element() as HTMLElement;
+
+  // multi-line cell must render taller than the single-line cell
+  expect(row1.clientHeight).toBeGreaterThan(row0.clientHeight);
+});
+
+test('rowHeight string + explicit enableVirtualization=true throws', async () => {
+  // Suppress React's error logging for this expected render error
+  vi.mocked(console.error).mockImplementation(() => {});
+
+  await expect(
+    setup({
+      columns: [{ key: 'id', name: 'ID' }],
+      rows: [{ id: 0 }],
+      rowHeight: 'auto',
+      enableVirtualization: true
+    })
+  ).rejects.toThrow('`rowHeight` cannot be a string when `enableVirtualization` is true.');
+
+  vi.mocked(console.error).mockClear();
+});

--- a/website/Nav.tsx
+++ b/website/Nav.tsx
@@ -91,6 +91,7 @@ export default function Nav({ direction, onDirectionChange }: Props) {
         <Link to="/ColumnsReordering">Columns Reordering</Link>
         <Link to="/ContextMenu">Context Menu</Link>
         <Link to="/CustomizableRenderers">Customizable Renderers</Link>
+        <Link to="/DynamicHeightCells">Dynamic Height Cells</Link>
         <Link to="/RowGrouping">Row Grouping</Link>
         <Link to="/HeaderFilters">Header Filters</Link>
         <Link to="/InfiniteScrolling">Infinite Scrolling</Link>

--- a/website/routeTree.gen.ts
+++ b/website/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ColumnsReorderingRouteImport } from './routes/ColumnsReorderin
 import { Route as CommonFeaturesRouteImport } from './routes/CommonFeatures'
 import { Route as ContextMenuRouteImport } from './routes/ContextMenu'
 import { Route as CustomizableRenderersRouteImport } from './routes/CustomizableRenderers'
+import { Route as DynamicHeightCellsRouteImport } from './routes/DynamicHeightCells'
 import { Route as HeaderFiltersRouteImport } from './routes/HeaderFilters'
 import { Route as InfiniteScrollingRouteImport } from './routes/InfiniteScrolling'
 import { Route as MasterDetailRouteImport } from './routes/MasterDetail'
@@ -79,6 +80,11 @@ const ContextMenuRoute = ContextMenuRouteImport.update({
 const CustomizableRenderersRoute = CustomizableRenderersRouteImport.update({
   id: '/CustomizableRenderers',
   path: '/CustomizableRenderers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DynamicHeightCellsRoute = DynamicHeightCellsRouteImport.update({
+  id: '/DynamicHeightCells',
+  path: '/DynamicHeightCells',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HeaderFiltersRoute = HeaderFiltersRouteImport.update({
@@ -148,6 +154,7 @@ export interface FileRoutesByFullPath {
   '/CommonFeatures': typeof CommonFeaturesRoute
   '/ContextMenu': typeof ContextMenuRoute
   '/CustomizableRenderers': typeof CustomizableRenderersRoute
+  '/DynamicHeightCells': typeof DynamicHeightCellsRoute
   '/HeaderFilters': typeof HeaderFiltersRoute
   '/InfiniteScrolling': typeof InfiniteScrollingRoute
   '/MasterDetail': typeof MasterDetailRoute
@@ -171,6 +178,7 @@ export interface FileRoutesByTo {
   '/CommonFeatures': typeof CommonFeaturesRoute
   '/ContextMenu': typeof ContextMenuRoute
   '/CustomizableRenderers': typeof CustomizableRenderersRoute
+  '/DynamicHeightCells': typeof DynamicHeightCellsRoute
   '/HeaderFilters': typeof HeaderFiltersRoute
   '/InfiniteScrolling': typeof InfiniteScrollingRoute
   '/MasterDetail': typeof MasterDetailRoute
@@ -195,6 +203,7 @@ export interface FileRoutesById {
   '/CommonFeatures': typeof CommonFeaturesRoute
   '/ContextMenu': typeof ContextMenuRoute
   '/CustomizableRenderers': typeof CustomizableRenderersRoute
+  '/DynamicHeightCells': typeof DynamicHeightCellsRoute
   '/HeaderFilters': typeof HeaderFiltersRoute
   '/InfiniteScrolling': typeof InfiniteScrollingRoute
   '/MasterDetail': typeof MasterDetailRoute
@@ -220,6 +229,7 @@ export interface FileRouteTypes {
     | '/CommonFeatures'
     | '/ContextMenu'
     | '/CustomizableRenderers'
+    | '/DynamicHeightCells'
     | '/HeaderFilters'
     | '/InfiniteScrolling'
     | '/MasterDetail'
@@ -243,6 +253,7 @@ export interface FileRouteTypes {
     | '/CommonFeatures'
     | '/ContextMenu'
     | '/CustomizableRenderers'
+    | '/DynamicHeightCells'
     | '/HeaderFilters'
     | '/InfiniteScrolling'
     | '/MasterDetail'
@@ -266,6 +277,7 @@ export interface FileRouteTypes {
     | '/CommonFeatures'
     | '/ContextMenu'
     | '/CustomizableRenderers'
+    | '/DynamicHeightCells'
     | '/HeaderFilters'
     | '/InfiniteScrolling'
     | '/MasterDetail'
@@ -290,6 +302,7 @@ export interface RootRouteChildren {
   CommonFeaturesRoute: typeof CommonFeaturesRoute
   ContextMenuRoute: typeof ContextMenuRoute
   CustomizableRenderersRoute: typeof CustomizableRenderersRoute
+  DynamicHeightCellsRoute: typeof DynamicHeightCellsRoute
   HeaderFiltersRoute: typeof HeaderFiltersRoute
   InfiniteScrollingRoute: typeof InfiniteScrollingRoute
   MasterDetailRoute: typeof MasterDetailRoute
@@ -373,6 +386,13 @@ declare module '@tanstack/react-router' {
       path: '/CustomizableRenderers'
       fullPath: '/CustomizableRenderers'
       preLoaderRoute: typeof CustomizableRenderersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/DynamicHeightCells': {
+      id: '/DynamicHeightCells'
+      path: '/DynamicHeightCells'
+      fullPath: '/DynamicHeightCells'
+      preLoaderRoute: typeof DynamicHeightCellsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/HeaderFilters': {
@@ -466,6 +486,7 @@ const rootRouteChildren: RootRouteChildren = {
   CommonFeaturesRoute: CommonFeaturesRoute,
   ContextMenuRoute: ContextMenuRoute,
   CustomizableRenderersRoute: CustomizableRenderersRoute,
+  DynamicHeightCellsRoute: DynamicHeightCellsRoute,
   HeaderFiltersRoute: HeaderFiltersRoute,
   InfiniteScrollingRoute: InfiniteScrollingRoute,
   MasterDetailRoute: MasterDetailRoute,

--- a/website/routes/DynamicHeightCells.tsx
+++ b/website/routes/DynamicHeightCells.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { createFileRoute } from '@tanstack/react-router';
+import { css } from 'ecij';
+
+import { DataGrid, type Column } from '../../src';
+import { useDirection } from '../directionContext';
+
+export const Route = createFileRoute('/DynamicHeightCells')({
+  component: DynamicHeightCells
+});
+
+interface Row {
+  id: number;
+  task: string;
+  complete: number;
+  priority: string;
+  issueType: string;
+  startDate: string;
+  completeDate: string;
+  dynamicContent: JSX.Element;
+}
+
+const columns: Column<Row>[] = [
+  {
+    key: 'id',
+    name: 'ID',
+    width: 80
+  },
+  {
+    key: 'task',
+    name: 'Title'
+  },
+  {
+    key: 'priority',
+    name: 'Priority'
+  },
+  {
+    key: 'issueType',
+    name: 'Issue Type'
+  },
+  {
+    key: 'complete',
+    name: '% Complete'
+  },
+  {
+    key: 'startDate',
+    name: 'Start Date'
+  },
+  {
+    key: 'completeDate',
+    name: 'Expected Complete',
+    width: 200
+  },
+  {
+    key: 'dynamicContent',
+    name: 'Dynamic HTML Content',
+    width: 200
+  }
+];
+
+function getRandomDate(start: Date, end: Date) {
+  return new Date(
+    start.getTime() + Math.random() * (end.getTime() - start.getTime())
+  ).toLocaleDateString();
+}
+
+function createRows(): Row[] {
+  const rows = [];
+  for (let i = 1; i < 500; i++) {
+    rows.push({
+      id: i,
+      task: `Task ${i}`,
+      complete: Math.min(100, Math.round(Math.random() * 110)),
+      priority: ['Critical', 'High', 'Medium', 'Low'][Math.floor(Math.random() * 3 + 1)],
+      issueType: ['Bug', 'Improvement', 'Epic', 'Story'][Math.floor(Math.random() * 3 + 1)],
+      startDate: getRandomDate(new Date(2015, 3, 1), new Date()),
+      completeDate: getRandomDate(new Date(), new Date(2016, 0, 1)),
+      dynamicContent: (() => {
+        const arr = [];
+        for (let i = 0; i < Math.ceil(Math.random() * 6); i++) {
+          arr.push(`Dynamic content ${i + 1}`);
+        }
+        return (
+          <ul>
+            {arr.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        );
+      })()
+    });
+  }
+
+  return rows;
+}
+
+const rootClassname = css`
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  gap: 10px;
+
+  > .rdg {
+    flex: 1;
+  }
+
+  .rdg-cell {
+    padding-block: 0.75em;
+  }
+`;
+
+function DynamicHeightCells() {
+  const direction = useDirection();
+  const [rows] = useState(createRows);
+
+  return (
+    <div className={rootClassname}>
+      <DataGrid columns={columns} rows={rows} direction={direction} rowHeight="auto" />
+    </div>
+  );
+}

--- a/website/routes/DynamicHeightCells.tsx
+++ b/website/routes/DynamicHeightCells.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 import { css } from 'ecij';
 


### PR DESCRIPTION
### Summary

- adds an option to use a string for rowHeight, which can be set to keyword values like `auto`, `fit-content`, `stretch`, etc. 
- updates `useViewportRows` to handle this, which adds new required new props `element` and `gridHeight` when using a string-based height.
- updates page up and page down to handle this.
- when using a string-based height, obviously the rowHeight calculations required for virtualization are not possible, so virtualization is disabled by default when using string rowHeights, and an error is thrown if you attempt to force virtualization on with rowHeights set to a string value.

### Background

At Grafana, our react-data-grid fork has been powering our Table panel for the past 9 months or so. One of the features we really need in our table panel is a mode where dynamic content can be supplied by a datasource (see [the Grafana docs](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/visualizations/table/#markdown--html)).

We forked from the package when the decision was made in this project to [drop support for React 18 on a non-breaking version update](https://github.com/Comcast/react-data-grid/pull/3503), but now that Grafana 13 is released and we are getting closer to having React 19 as the only supported version for Grafana going forward, we want to get back on the main package. But to do that we need dynamic row height support since we have added that in our fork and we now depend on that being available in some form. We're open to the specific form it takes, though, so please let us know if you have concerns with the approach in here.