### PR TITLE
Remove postcss dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "jspdf-autotable": "^5.0.7",
         "oxfmt": "0.51.0",
         "playwright": "~1.60.0",
-        "postcss": "^8.5.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "tsdown": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "jspdf-autotable": "^5.0.7",
     "oxfmt": "0.51.0",
     "playwright": "~1.60.0",
-    "postcss": "^8.5.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tsdown": "^0.22.0",


### PR DESCRIPTION
It's still installed as a direct dependency of `vite`, but I don't think we need to keep it otherwise?