### PR TITLE
fix: use :scope instead of & in relative querySelector

### DIFF
--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -9,11 +9,11 @@ export function scrollIntoView(element: Maybe<Element>, behavior: ScrollBehavior
 }
 
 function getRowToScroll(gridEl: HTMLDivElement) {
-  return gridEl.querySelector<HTMLDivElement>('& > [role="row"][tabindex="0"]');
+  return gridEl.querySelector<HTMLDivElement>(':scope > [role="row"][tabindex="0"]');
 }
 
 export function getCellToScroll(gridEl: HTMLDivElement) {
-  return gridEl.querySelector<HTMLDivElement>('& > [role="row"] > [tabindex="0"]');
+  return gridEl.querySelector<HTMLDivElement>(':scope > [role="row"] > [tabindex="0"]');
 }
 
 function focusElement(element: HTMLDivElement | null, shouldScroll: boolean) {


### PR DESCRIPTION
## Summary

`getRowToScroll` / `getCellToScroll` in `src/utils/domUtils.ts` build a relative selector to locate the focused row/cell inside the grid element, prefixed with the CSS-nesting `&` combinator:

```ts
gridEl.querySelector('& > [role="row"] > [tabindex="0"]')
```

Chromium accepts a leading `&` in a `querySelector` argument, but the standard token for "the element `querySelector` was called on" is `:scope`. Selector engines that follow the spec strictly — notably **jsdom (nwsapi)**, widely used in unit tests — throw:

```
SyntaxError: '& > [role="row"] > [tabindex="0"]' is not a valid selector
```

This breaks header/cell focus (`selectHeaderCell` → `setPosition` → `getCellToScroll`) in any jsdom-based test that clicks a header, and anywhere the engine doesn't special-case `&`.

## Change

Replace the leading `&` with `:scope` in both helpers. `:scope > …` is equivalent in the browser and valid across DOM implementations. No in-browser behavior change; the existing browser test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
