### PR TITLE
Dependabot: wider dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,26 +7,56 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@typescript/*'
+      build-tooling:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'vitest'
+          - 'vitest-*'
+          - '@vitest/*'
+          - 'tsdown'
+          - '@tsdown/*'
+          - 'playwright'
+        exclude-patterns:
+          - '@vitest/eslint-plugin'
+      quality:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@eslint-react/*'
+          - 'typescript-eslint'
+          - '@vitest/eslint-plugin'
+          - 'oxfmt'
+          - 'oxlint'
+          - 'oxlint-*'
       react:
         patterns:
           - 'react'
           - 'react-dom'
-      tanstack-router:
+          - '@types/react'
+          - '@types/react-dom'
+      tanstack:
         patterns:
-          - '@tanstack/react-router'
-          - '@tanstack/router-plugin'
-      tsdown:
+          - '@tanstack/*'
+      # everything else: single PR for minor/patch bumps,
+      # majors still land individually
+      dependencies:
         patterns:
-          - 'tsdown'
-          - '@tsdown/*'
-      vitest:
-        patterns:
-          - 'vitest'
-          - '@vitest/*'
-        exclude-patterns:
-          - '@vitest/eslint-plugin'
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Inspiration: https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/