### PR TITLE
Add row spanning, per-cell styling, nav bounds, and Enter-to-advance …

### DIFF
--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -1,0 +1,52 @@
+# Proposed changes
+
+## Summary
+
+1. **Per-cell custom styling** — `column.styleCellClass(row, column)` and
+   `column.myCellStyle` (object or `(row, colIdx) => style`) added to
+   `Column` in `src/types.ts`, wired into `src/Cell.tsx`.
+2. **`fixTop` / `fixLeft` navigation bounds** — new `DataGrid` props that
+   stop keyboard navigation/selection from moving above `fixTop` data rows
+   or left of `fixLeft` columns (without affecting pointer-driven selection
+   or header-row navigation). Implemented in `src/DataGrid.tsx` (see
+   `minNavRowIdx`, `fixLeft` usage in `getNextPosition`/`navigate`) and
+   `src/utils/activePositionUtils.ts` (`canExitGrid` gained `minColIdx`,
+   `getNextActivePosition`'s `CHANGE_ROW` column-wrap respects `minColIdx`).
+3. **Row spanning** — new `column.rowSpan(args)` returning
+   `[spanIndex, totalSpan]`; only the `spanIndex === 1` "master" cell
+   renders and visually covers the following rows via CSS
+   `grid-row-end: span N`. New file `src/utils/rowSpanUtils.ts`
+   (`getRowSpan`, `isRowSpanCovered`), wired into `src/Row.tsx` (filters
+   out covered cells, computes span for the master, and stretches the
+   row's own grid track to match the largest span it contains so the
+   `subgrid` row template has enough tracks to span into) and `src/Cell.tsx`
+   / `src/utils/styleUtils.ts` (`getCellStyle` gained a `rowSpan` param).
+   Demo: `website/routes/RowSpanning.tsx`, linked in `website/Nav.tsx`.
+4. **Enter-to-advance in cell editor** ("Excel-like" — commit + move down
+   one row). `src/DataGrid.tsx`'s `getNextPosition` gained an `'Enter'`
+   case (same as `ArrowDown`) reached only via the editor's own
+   `navigate(event)` call, not the normal active-cell key handler.
+   `src/EditCell.tsx`'s `handleKeyDown` now calls `onClose(true, false)`
+   then `navigate(event)` on Enter.
+
+## Verification done
+
+- `npm run build` (tsdown, library) — clean
+- `npm run build:website` (vite) — clean
+- `npm run typecheck` (`tsc --build`) — clean
+- `npm run eslint` — 0 errors, 0 warnings
+- `npm run format:check` (oxfmt) — clean
+- Row spanning and Enter-to-advance were visually verified live in a
+  headless-Chromium browser (Playwright) against the Vite dev server.
+
+## Known gaps / things to watch
+
+- `npm test` (vitest) has one pre-existing failing test
+  (`test/browser/column/renderEditCell.test.tsx`, "should open and commit
+  changes on enter") that asserts the old behavior — focus staying on the
+  same cell after committing an edit with Enter. This is superseded by the
+  new Enter-to-advance behavior (item 4 above) and the test needs updating
+  to match.
+- No changes were made to `EditCell.tsx`'s styling to account for
+  `rowSpan` while editing a spanned cell — only `Cell.tsx` got
+  span-aware styling.

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -16,6 +16,7 @@ const cellDraggedOverClassname = `rdg-cell-dragged-over ${cellDraggedOver}`;
 function Cell<R, SR>({
   column,
   colSpan,
+  rowSpan,
   isCellActive,
   isDraggedOver,
   row,
@@ -36,14 +37,17 @@ function Cell<R, SR>({
 }: CellRendererProps<R, SR>) {
   const { tabIndex, childTabIndex, onFocus } = useRovingTabIndex(isCellActive);
 
-  const { cellClass } = column;
+  const { cellClass, styleCellClass, myCellStyle } = column;
+  const styleClassOverride = styleCellClass?.(row, column);
   className = getCellClassname(
     column,
     isDraggedOver && cellDraggedOverClassname,
-    typeof cellClass === 'function' ? cellClass(row) : cellClass,
+    styleClassOverride ?? (typeof cellClass === 'function' ? cellClass(row) : cellClass),
     className
   );
   const isEditable = isCellEditableUtil(column, row);
+  const cellStyleOverride =
+    typeof myCellStyle === 'function' ? myCellStyle(row, column.idx) : myCellStyle;
 
   function setActivePositionWrapper(enableEditor = false) {
     setActivePosition({ rowIdx, idx: column.idx }, { enableEditor });
@@ -97,12 +101,14 @@ function Cell<R, SR>({
       role="gridcell"
       aria-colindex={column.idx + 1} // aria-colindex is 1-based
       aria-colspan={colSpan}
+      aria-rowspan={rowSpan}
       aria-selected={isCellActive}
       aria-readonly={!isEditable || undefined}
       tabIndex={tabIndex}
       className={className}
       style={{
-        ...getCellStyle(column, colSpan),
+        ...getCellStyle(column, colSpan, rowSpan),
+        ...cellStyleOverride,
         ...style
       }}
       onClick={handleClick}

--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -206,6 +206,17 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    */
   /** @default true */
   enableVirtualization?: Maybe<boolean>;
+  /**
+   * The number of rows, from the top of the data rows, that keyboard navigation and
+   * selection cannot move above
+   * @default 0
+   */
+  fixTop?: Maybe<number>;
+  /**
+   * The column index that keyboard navigation and selection cannot move to the left of
+   * @default 0
+   */
+  fixLeft?: Maybe<number>;
 
   /**
    * Miscellaneous
@@ -248,6 +259,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     summaryRowHeight: rawSummaryRowHeight,
     columnWidths: columnWidthsRaw,
     onColumnWidthsChange: onColumnWidthsChangeRaw,
+    fixTop: rawFixTop,
+    fixLeft: rawFixLeft,
     // Feature props
     selectedRows,
     isRowSelectionDisabled,
@@ -376,6 +389,11 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const maxRowIdx = rows.length + bottomSummaryRowsCount - 1;
   const mainHeaderRowIdx = minRowIdx + groupedColumnHeaderRowsCount;
   const maxColIdx = columns.length - 1;
+  // Lower bounds for keyboard navigation/selection within the data rows/columns,
+  // leaving header/summary row navigation and pointer-driven selection unaffected.
+  const fixTop = rawFixTop ?? 0;
+  const fixLeft = rawFixLeft ?? 0;
+  const minNavRowIdx = Math.max(minRowIdx, fixTop);
   const headerRowsHeight = headerRowsCount * headerRowHeight;
   const summaryRowsHeight = summaryRowsCount * summaryRowHeight;
   const clientHeight = gridHeight - headerRowsHeight - summaryRowsHeight;
@@ -844,12 +862,14 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
         };
       }
       case 'ArrowDown':
+      case 'Enter':
         return { idx, rowIdx: rowIdx + 1 };
       case leftKey: {
+        const minIdx = rowIdx >= 0 ? fixLeft : 0;
         const nextIdx = idx - 1;
         return {
           // avoid selecting header rows
-          idx: rowIdx < -topSummaryRowsCount && nextIdx < 0 ? 0 : nextIdx,
+          idx: rowIdx < -topSummaryRowsCount && nextIdx < 0 ? 0 : Math.max(nextIdx, minIdx),
           rowIdx
         };
       }
@@ -860,13 +880,13 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       case 'Home':
         // If row is selected then move focus to the first header row's cell.
         if (activePositionIsRow || ctrlKey) return { idx: 0, rowIdx: minRowIdx };
-        return { idx: 0, rowIdx };
+        return { idx: rowIdx >= 0 ? fixLeft : 0, rowIdx };
       case 'End':
         // If row is selected then move focus to the last row.
         if (activePositionIsRow) return { idx, rowIdx: maxRowIdx };
         return { idx: maxColIdx, rowIdx: ctrlKey ? maxRowIdx : rowIdx };
       case 'PageUp': {
-        if (rowIdx === minRowIdx) return activePosition;
+        if (rowIdx === minRowIdx || rowIdx === minNavRowIdx) return activePosition;
         const nextRowY = getRowTop(rowIdx) + getRowHeight(rowIdx) - clientHeight;
         return { idx, rowIdx: nextRowY > 0 ? findRowIdx(nextRowY) : 0 };
       }
@@ -888,7 +908,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
         canExitGrid({
           shiftKey,
           maxColIdx,
-          minRowIdx,
+          minColIdx: fixLeft,
+          minRowIdx: minNavRowIdx,
           maxRowIdx,
           activePosition
         })
@@ -916,7 +937,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
       rows,
       topSummaryRows,
       bottomSummaryRows,
-      minRowIdx,
+      minRowIdx: minNavRowIdx,
+      minColIdx: fixLeft,
       mainHeaderRowIdx,
       maxRowIdx,
       lastStartFrozenColumnIndex,

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -145,7 +145,9 @@ export default function EditCell<R, SR>({
       // Discard changes
       onClose();
     } else if (event.key === 'Enter') {
-      onClose(true);
+      // Commit changes and move to the cell below, like Excel
+      onClose(true, false);
+      navigate(event);
     } else if (onEditorNavigation(event)) {
       navigate(event);
     }

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 
 import { RowSelectionContext, type RowSelectionContextValue } from './hooks';
-import { classnames } from './utils';
+import { classnames, getRowSpan, isRowSpanCovered } from './utils';
 import type { RenderRowProps } from './types';
 import { useDefaultRenderers } from './DataGridDefaultRenderersContext';
 import { rowClassname, rowActiveClassname } from './style/row';
@@ -40,8 +40,19 @@ function Row<R, SR>({
     className
   );
 
+  // Track the largest rowSpan among this row's master cells so the row's own grid track
+  // can be stretched to match via gridRowEnd below — otherwise the `subgrid` row template
+  // only exposes a single track and a cell's `grid-row-end: span N` has nowhere to span into.
+  let maxRowSpan = 1;
+
   const cells = iterateOverViewportColumnsForRow(activeCellIdx, { type: 'ROW', row })
+    .filter(([column]) => !isRowSpanCovered(column, { type: 'ROW', row }))
     .map(([column, isCellActive, colSpan]) => {
+      const rowSpan = getRowSpan(column, { type: 'ROW', row });
+      if (rowSpan !== undefined && rowSpan > maxRowSpan) {
+        maxRowSpan = rowSpan;
+      }
+
       if (isCellActive && activeCellEditor) {
         return activeCellEditor;
       }
@@ -49,6 +60,7 @@ function Row<R, SR>({
       return renderCell(column.key, {
         column,
         colSpan,
+        rowSpan,
         row,
         rowIdx,
         isDraggedOver: draggedOverCellIdx === column.idx,
@@ -76,6 +88,7 @@ function Row<R, SR>({
         className={className}
         style={{
           gridRowStart,
+          gridRowEnd: maxRowSpan > 1 ? `span ${maxRowSpan}` : undefined,
           ...style
         }}
         {...props}

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,14 @@ export interface Column<TRow, TSummaryRow = unknown> {
   readonly maxWidth?: Maybe<number>;
   /** Class name(s) for cells */
   readonly cellClass?: Maybe<string | ((row: TRow) => Maybe<string>)>;
+  /** Class name(s) for cells, takes precedence over `cellClass` */
+  readonly styleCellClass?: Maybe<
+    (row: TRow, column: CalculatedColumn<TRow, TSummaryRow>) => Maybe<string>
+  >;
+  /** Inline style for cells, merged over the grid's own cell positioning styles */
+  readonly myCellStyle?: Maybe<
+    React.CSSProperties | ((row: TRow, colIdx: number) => Maybe<React.CSSProperties>)
+  >;
   /** Class name(s) for the header cell */
   readonly headerCellClass?: Maybe<string>;
   /** Class name(s) for summary cells */
@@ -46,6 +54,12 @@ export interface Column<TRow, TSummaryRow = unknown> {
   /** Enables cell editing. If set and no editor property specified, then a textinput will be used as the cell editor */
   readonly editable?: Maybe<boolean | ((row: TRow) => boolean)>;
   readonly colSpan?: Maybe<(args: ColSpanArgs<TRow, TSummaryRow>) => Maybe<number>>;
+  /**
+   * Returns `[spanIndex, totalSpan]` for the given row, where `spanIndex` is the
+   * 1-based position of `row` within the span. Only the cell with `spanIndex === 1`
+   * is rendered; it visually covers the following `totalSpan - 1` rows.
+   */
+  readonly rowSpan?: Maybe<(args: RowSpanArgs<TRow>) => Maybe<readonly [number, number]>>;
   /** Determines whether column is frozen, and on which edge.
    *  `true` is an alias for `'start'` for backwards compatibility. */
   readonly frozen?: Maybe<ColumnFrozen>;
@@ -179,6 +193,7 @@ export interface CellRendererProps<TRow, TSummaryRow> extends BaseCellRendererPr
   column: CalculatedColumn<TRow, TSummaryRow>;
   row: TRow;
   colSpan: number | undefined;
+  rowSpan: number | undefined;
   isDraggedOver: boolean;
   isCellActive: boolean;
   onRowChange: (column: CalculatedColumn<TRow, TSummaryRow>, rowIdx: number, newRow: TRow) => void;
@@ -339,6 +354,11 @@ export type ColSpanArgs<TRow, TSummaryRow> =
   | { readonly type: 'HEADER' }
   | { readonly type: 'ROW'; readonly row: TRow }
   | { readonly type: 'SUMMARY'; readonly row: TSummaryRow };
+
+export interface RowSpanArgs<TRow> {
+  readonly type: 'ROW';
+  readonly row: TRow;
+}
 
 export type RowHeightArgs<TRow> =
   | { type: 'ROW'; row: TRow }

--- a/src/utils/activePositionUtils.ts
+++ b/src/utils/activePositionUtils.ts
@@ -25,6 +25,7 @@ interface GetNextPositionOpts<R, SR> {
   topSummaryRows: Maybe<readonly SR[]>;
   bottomSummaryRows: Maybe<readonly SR[]>;
   minRowIdx: number;
+  minColIdx?: number;
   mainHeaderRowIdx: number;
   maxRowIdx: number;
   activePosition: Position;
@@ -101,6 +102,7 @@ export function getNextActivePosition<R, SR>({
   topSummaryRows,
   bottomSummaryRows,
   minRowIdx,
+  minColIdx = 0,
   mainHeaderRowIdx,
   maxRowIdx,
   activePosition: { idx: activeIdx, rowIdx: activeRowIdx },
@@ -187,19 +189,23 @@ export function getNextActivePosition<R, SR>({
 
   if (cellNavigationMode === 'CHANGE_ROW') {
     const isAfterLastColumn = nextIdx === columnsCount;
-    const isBeforeFirstColumn = nextIdx === -1;
+    const isBeforeFirstColumn = nextIdx < minColIdx && nextRowIdx >= 0;
 
     if (isAfterLastColumn) {
       const isLastRow = nextRowIdx === maxRowIdx;
       if (!isLastRow) {
-        nextIdx = 0;
+        nextIdx = minColIdx;
         nextRowIdx += 1;
+      } else {
+        nextIdx = minColIdx;
       }
     } else if (isBeforeFirstColumn) {
       const isFirstRow = nextRowIdx === minRowIdx;
       if (!isFirstRow) {
         nextRowIdx -= 1;
         nextIdx = columnsCount - 1;
+      } else {
+        nextIdx = minColIdx;
       }
       setColSpan(false);
     }
@@ -228,6 +234,7 @@ export function getNextActivePosition<R, SR>({
 
 interface CanExitGridOpts {
   maxColIdx: number;
+  minColIdx?: number;
   minRowIdx: number;
   maxRowIdx: number;
   activePosition: Position;
@@ -236,6 +243,7 @@ interface CanExitGridOpts {
 
 export function canExitGrid({
   maxColIdx,
+  minColIdx = 0,
   minRowIdx,
   maxRowIdx,
   activePosition: { rowIdx, idx },
@@ -243,7 +251,7 @@ export function canExitGrid({
 }: CanExitGridOpts): boolean {
   // Exit the grid if we're at the first or last cell of the grid
   const atLastCellInRow = idx === maxColIdx;
-  const atFirstCellInRow = idx === 0;
+  const atFirstCellInRow = idx === minColIdx;
   const atLastRow = rowIdx === maxRowIdx;
   const atFirstRow = rowIdx === minRowIdx;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './eventUtils';
 export * from './frozenColumnUtils';
 export * from './keyboardUtils';
 export * from './renderMeasuringCells';
+export * from './rowSpanUtils';
 export * from './styleUtils';
 
 export const { min, max, floor, abs } = Math;

--- a/src/utils/rowSpanUtils.ts
+++ b/src/utils/rowSpanUtils.ts
@@ -1,0 +1,40 @@
+import type { CalculatedColumn, RowSpanArgs } from '../types';
+
+/**
+ * Returns the number of rows the cell at `row` should visually span, or `undefined`
+ * if this row is not the first (master) row of a span. Only the master cell is
+ * rendered; `Row` skips rendering the covered rows for this column.
+ */
+export function getRowSpan<R, SR>(
+  column: CalculatedColumn<R, SR>,
+  args: RowSpanArgs<R>
+): number | undefined {
+  if (typeof column.rowSpan !== 'function') return undefined;
+
+  const result = column.rowSpan(args);
+  if (result == null) return undefined;
+
+  const [spanIndex, totalSpan] = result;
+  if (!Number.isInteger(totalSpan) || totalSpan <= 1) return undefined;
+  if (spanIndex !== 1) return undefined;
+
+  return totalSpan;
+}
+
+/**
+ * Returns true if this row is a non-master row within a column's row span, i.e.
+ * it is visually covered by a master cell rendered on an earlier row and should
+ * not render its own cell for this column.
+ */
+export function isRowSpanCovered<R, SR>(
+  column: CalculatedColumn<R, SR>,
+  args: RowSpanArgs<R>
+): boolean {
+  if (typeof column.rowSpan !== 'function') return false;
+
+  const result = column.rowSpan(args);
+  if (result == null) return false;
+
+  const [spanIndex, totalSpan] = result;
+  return Number.isInteger(totalSpan) && totalSpan > 1 && spanIndex !== 1;
+}

--- a/src/utils/styleUtils.ts
+++ b/src/utils/styleUtils.ts
@@ -29,12 +29,19 @@ export function getHeaderCellStyle<R, SR>(
 
 export function getCellStyle<R, SR>(
   column: CalculatedColumn<R, SR>,
-  colSpan = 1
+  colSpan = 1,
+  rowSpan?: number
 ): React.CSSProperties {
   const index = column.idx + 1;
   return {
     gridColumnStart: index,
     gridColumnEnd: index + colSpan,
+    ...(rowSpan !== undefined && {
+      gridRowEnd: `span ${rowSpan}`,
+      // rowSpan cells must render above the background of the rows they span over,
+      // otherwise those rows' opaque background paints over the spanning cell's borders
+      zIndex: 1
+    }),
     insetInlineStart: isStartFrozen(column.frozen)
       ? `var(--rdg-frozen-start-${column.idx})`
       : undefined,

--- a/website/Nav.tsx
+++ b/website/Nav.tsx
@@ -87,6 +87,7 @@ export default function Nav({ direction, onDirectionChange }: Props) {
         <Link to="/AllFeatures">All Features</Link>
         <Link to="/CellNavigation">Cell Navigation</Link>
         <Link to="/ColumnSpanning">Column Spanning</Link>
+        <Link to="/RowSpanning">Row Spanning</Link>
         <Link to="/ColumnGrouping">Column Grouping</Link>
         <Link to="/ColumnsReordering">Columns Reordering</Link>
         <Link to="/ContextMenu">Context Menu</Link>

--- a/website/routeTree.gen.ts
+++ b/website/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as MillionCellsRouteImport } from './routes/MillionCells'
 import { Route as NoRowsRouteImport } from './routes/NoRows'
 import { Route as ResizableGridRouteImport } from './routes/ResizableGrid'
 import { Route as RowGroupingRouteImport } from './routes/RowGrouping'
+import { Route as RowSpanningRouteImport } from './routes/RowSpanning'
 import { Route as RowsReorderingRouteImport } from './routes/RowsReordering'
 import { Route as ScrollToCellRouteImport } from './routes/ScrollToCell'
 import { Route as TreeViewRouteImport } from './routes/TreeView'
@@ -116,6 +117,11 @@ const RowGroupingRoute = RowGroupingRouteImport.update({
   path: '/RowGrouping',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RowSpanningRoute = RowSpanningRouteImport.update({
+  id: '/RowSpanning',
+  path: '/RowSpanning',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RowsReorderingRoute = RowsReorderingRouteImport.update({
   id: '/RowsReordering',
   path: '/RowsReordering',
@@ -155,6 +161,7 @@ export interface FileRoutesByFullPath {
   '/NoRows': typeof NoRowsRoute
   '/ResizableGrid': typeof ResizableGridRoute
   '/RowGrouping': typeof RowGroupingRoute
+  '/RowSpanning': typeof RowSpanningRoute
   '/RowsReordering': typeof RowsReorderingRoute
   '/ScrollToCell': typeof ScrollToCellRoute
   '/TreeView': typeof TreeViewRoute
@@ -178,6 +185,7 @@ export interface FileRoutesByTo {
   '/NoRows': typeof NoRowsRoute
   '/ResizableGrid': typeof ResizableGridRoute
   '/RowGrouping': typeof RowGroupingRoute
+  '/RowSpanning': typeof RowSpanningRoute
   '/RowsReordering': typeof RowsReorderingRoute
   '/ScrollToCell': typeof ScrollToCellRoute
   '/TreeView': typeof TreeViewRoute
@@ -202,6 +210,7 @@ export interface FileRoutesById {
   '/NoRows': typeof NoRowsRoute
   '/ResizableGrid': typeof ResizableGridRoute
   '/RowGrouping': typeof RowGroupingRoute
+  '/RowSpanning': typeof RowSpanningRoute
   '/RowsReordering': typeof RowsReorderingRoute
   '/ScrollToCell': typeof ScrollToCellRoute
   '/TreeView': typeof TreeViewRoute
@@ -227,6 +236,7 @@ export interface FileRouteTypes {
     | '/NoRows'
     | '/ResizableGrid'
     | '/RowGrouping'
+    | '/RowSpanning'
     | '/RowsReordering'
     | '/ScrollToCell'
     | '/TreeView'
@@ -250,6 +260,7 @@ export interface FileRouteTypes {
     | '/NoRows'
     | '/ResizableGrid'
     | '/RowGrouping'
+    | '/RowSpanning'
     | '/RowsReordering'
     | '/ScrollToCell'
     | '/TreeView'
@@ -273,6 +284,7 @@ export interface FileRouteTypes {
     | '/NoRows'
     | '/ResizableGrid'
     | '/RowGrouping'
+    | '/RowSpanning'
     | '/RowsReordering'
     | '/ScrollToCell'
     | '/TreeView'
@@ -297,6 +309,7 @@ export interface RootRouteChildren {
   NoRowsRoute: typeof NoRowsRoute
   ResizableGridRoute: typeof ResizableGridRoute
   RowGroupingRoute: typeof RowGroupingRoute
+  RowSpanningRoute: typeof RowSpanningRoute
   RowsReorderingRoute: typeof RowsReorderingRoute
   ScrollToCellRoute: typeof ScrollToCellRoute
   TreeViewRoute: typeof TreeViewRoute
@@ -424,6 +437,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RowGroupingRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/RowSpanning': {
+      id: '/RowSpanning'
+      path: '/RowSpanning'
+      fullPath: '/RowSpanning'
+      preLoaderRoute: typeof RowSpanningRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/RowsReordering': {
       id: '/RowsReordering'
       path: '/RowsReordering'
@@ -473,6 +493,7 @@ const rootRouteChildren: RootRouteChildren = {
   NoRowsRoute: NoRowsRoute,
   ResizableGridRoute: ResizableGridRoute,
   RowGroupingRoute: RowGroupingRoute,
+  RowSpanningRoute: RowSpanningRoute,
   RowsReorderingRoute: RowsReorderingRoute,
   ScrollToCellRoute: ScrollToCellRoute,
   TreeViewRoute: TreeViewRoute,

--- a/website/routes/RowSpanning.tsx
+++ b/website/routes/RowSpanning.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { css } from 'ecij';
+
+import { DataGrid, type Column } from '../../src';
+import { renderCoordinates } from '../renderers';
+import { useDirection } from '../directionContext';
+
+export const Route = createFileRoute('/RowSpanning')({
+  component: RowSpanning
+});
+
+type Row = number;
+const rows: readonly Row[] = Array.from({ length: 100 }, (_, i) => i);
+
+const rowSpanClassname = css`
+  background-color: #ffb300;
+  color: black;
+  text-align: center;
+`;
+
+const columns: Column<Row>[] = [];
+
+for (let i = 0; i < 10; i++) {
+  const key = String(i);
+  columns.push({
+    key,
+    name: key,
+    resizable: true,
+    renderCell: renderCoordinates,
+    rowSpan(args) {
+      if (key === '0') {
+        if (args.row === 1) return [1, 3];
+        if (args.row === 2) return [2, 3];
+        if (args.row === 3) return [3, 3];
+      }
+      return undefined;
+    },
+    cellClass(row) {
+      if (key === '0' && row >= 1 && row <= 3) {
+        return rowSpanClassname;
+      }
+      return undefined;
+    }
+  });
+}
+
+function RowSpanning() {
+  const direction = useDirection();
+
+  return (
+    <DataGrid
+      aria-label="Row Spanning Example"
+      columns={columns}
+      rows={rows}
+      rowHeight={22}
+      className="fill-grid"
+      direction={direction}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- **Row spanning** — `column.rowSpan(args)` returns `[spanIndex, totalSpan]`; only the `spanIndex === 1` "master" cell renders and visually covers the following rows via CSS `grid-row-end`. The containing row's own grid track is stretched to match the largest span it contains, so the `subgrid` row template has enough tracks to span into (`src/utils/rowSpanUtils.ts`, `src/Row.tsx`, `src/Cell.tsx`, `src/utils/styleUtils.ts`). Demo at `website/routes/RowSpanning.tsx`.
- **Per-cell custom styling** — `column.styleCellClass(row, column)` and `column.myCellStyle` (object or `(row, colIdx) => style`) for styling individual cells beyond what `cellClass` supports today.
- **`fixTop` / `fixLeft` navigation bounds** — new `DataGrid` props that stop keyboard navigation/selection from moving above `fixTop` data rows or left of `fixLeft` columns, without affecting pointer-driven selection or header-row navigation.
- **Enter-to-advance in the cell editor** — Excel-like behavior: pressing Enter commits the edit and moves the active cell to the row below, then closes the editor.

## Test plan

- [x] `npm run build` (tsdown) — clean
- [x] `npm run build:website` (vite) — clean
- [x] `npm run typecheck` — clean
- [x] `npm run eslint` — 0 errors, 0 warnings
- [x] `npm run format:check` — clean
- [x] Row spanning and Enter-to-advance manually verified in the browser against the Vite dev server (`website/routes/RowSpanning.tsx`, `CommonFeatures` demo)
- [ ] `npm test` — one pre-existing test in `test/browser/column/renderEditCell.test.tsx` ("should open and commit changes on enter") asserts the old behavior (focus stays on the same cell after Enter) and needs updating to match the new Enter-to-advance behavior; happy to update it if this direction looks good to maintainers.
