### PR TITLE
Move .cache, tweak eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.cache
 /.claude
 /dist
 /lib

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,25 +1,11 @@
+import { fileURLToPath } from 'node:url';
 import markdown from '@eslint/markdown';
-import { defineConfig, globalIgnores } from 'eslint/config';
+import { defineConfig, includeIgnoreFile } from 'eslint/config';
 
 export default defineConfig([
-  globalIgnores([
-    '.cache',
-    '.claude',
-    '.nitro',
-    '.output',
-    '.tanstack',
-    'coverage',
-    'dist',
-    'lib',
-    // linted by oxlint
-    '**/*.{js,ts,tsx}'
-  ]),
-
-  {
-    linterOptions: {
-      reportUnusedInlineConfigs: 'warn'
-    }
-  },
+  includeIgnoreFile(fileURLToPath(import.meta.resolve('./.gitignore')), {
+    gitignoreResolution: true
+  }),
 
   {
     name: 'markdown',
@@ -28,6 +14,9 @@ export default defineConfig([
       markdown
     },
     language: 'markdown/gfm',
+    linterOptions: {
+      reportUnusedInlineConfigs: 'warn'
+    },
     rules: {
       // `@eslint/markdown` rules
       // https://github.com/eslint/markdown/blob/main/README.md#rules

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "moduleDetection": "force",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "outDir": "./.cache/ts",
+    "outDir": "./node_modules/.cache/ts",
     "target": "esnext",
     "verbatimModuleSyntax": true
   }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ESNext"],
-    "module": "NodeNext"
+    "module": "NodeNext",
+    "types": ["node"]
   },
   "include": ["eslint.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,7 @@ const playwrightOptions: PlaywrightProviderOptions = {
 
 export default defineConfig(({ isPreview }): ViteUserConfig => ({
   base: '/react-data-grid/',
-  cacheDir: '.cache/vite',
+  cacheDir: 'node_modules/.cache/vite',
   clearScreen: false,
   build: {
     // chunkImportMap: true,


### PR DESCRIPTION
- I've moved the common cache folder to `node_modules/.cache`
  - the location of the `.cache` folder was convenient, but we rely on it less and less, so we rarely need to manually delete it nowadays
  - we have to manually ignore it in all tools
    - vite plugins handle files under `.cache/vite` if we forget to configure all the `exclude`s
    - this caused issues with the react compiler, which is why I've opened this PR
- I've also tweaked the eslint config
  - much like oxfmt/oxlint, it now respects our `.gitignore`, so we don't need to keep these in sync anymore
    - https://eslint.org/docs/latest/use/configure/ignore#include-gitignore-files
  - keeping `globalIgnores(['**/*.{js,ts,tsx}'])` made no difference so I've removed it as well
    - FYI we could speed up eslint with `globalIgnores(['src/', 'test/', 'website/'])`, but it's negligible
  - `linterOptions` is now inlined in the only config object left