### PR TITLE
Resolve React Compiler diagnostics

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -507,9 +507,38 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   const selectHeaderRowLatest = useLatestFunc(selectHeaderRow);
   const selectRowLatest = useLatestFunc(selectRow);
   const handleFormatterRowChangeLatest = useLatestFunc(updateRow);
-  // oxlint-disable-next-line react/immutability
   const setPositionLatest = useLatestFunc(setPosition);
   const selectHeaderCellLatest = useLatestFunc(selectHeaderCell);
+
+  function setPosition(position: Position, options?: SetActivePositionOptions): void {
+    const { isPositionInActiveBounds } = validatePosition(position);
+    if (!isPositionInActiveBounds) return;
+    commitEditorChanges();
+
+    const samePosition = isSamePosition(activePosition, position);
+
+    if (options?.enableEditor && isCellEditable(position)) {
+      const row = rows[position.rowIdx];
+      setActivePosition({ ...position, mode: 'EDIT', row, originalRow: row });
+    } else if (samePosition) {
+      // Avoid re-renders if the selected cell state is the same
+      scrollIntoView(getCellToScroll(gridRef.current!));
+    } else {
+      const newPosition: ActivePosition = { ...position, mode: 'ACTIVE' };
+      setActivePosition(newPosition);
+      if (options?.shouldFocus) {
+        setPositionToFocus(newPosition);
+      }
+    }
+
+    if (onActivePositionChange && !samePosition) {
+      onActivePositionChange({
+        rowIdx: position.rowIdx,
+        row: rows[position.rowIdx],
+        column: columns[position.idx]
+      });
+    }
+  }
 
   /**
    * Misc hooks
@@ -798,36 +827,6 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     );
   }
 
-  function setPosition(position: Position, options?: SetActivePositionOptions): void {
-    const { isPositionInActiveBounds } = validatePosition(position);
-    if (!isPositionInActiveBounds) return;
-    commitEditorChanges();
-
-    const samePosition = isSamePosition(activePosition, position);
-
-    if (options?.enableEditor && isCellEditable(position)) {
-      const row = rows[position.rowIdx];
-      setActivePosition({ ...position, mode: 'EDIT', row, originalRow: row });
-    } else if (samePosition) {
-      // Avoid re-renders if the selected cell state is the same
-      scrollIntoView(getCellToScroll(gridRef.current!));
-    } else {
-      const newPosition: ActivePosition = { ...position, mode: 'ACTIVE' };
-      setActivePosition(newPosition);
-      if (options?.shouldFocus) {
-        setPositionToFocus(newPosition);
-      }
-    }
-
-    if (onActivePositionChange && !samePosition) {
-      onActivePositionChange({
-        rowIdx: position.rowIdx,
-        row: rows[position.rowIdx],
-        column: columns[position.idx]
-      });
-    }
-  }
-
   function selectHeaderCell({ idx, rowIdx }: Position): void {
     setPosition({ rowIdx: minRowIdx + rowIdx - 1, idx });
   }
@@ -1087,24 +1086,15 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     );
   }
 
-  function* iterateOverViewportRowIdx() {
-    const activeRowIdx = activePosition.rowIdx;
-
-    if (activePositionIsInViewport && activeRowIdx < rowOverscanStartIdx) {
-      yield activeRowIdx;
-    }
-    for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
-      yield rowIdx;
-    }
-    if (activePositionIsInViewport && activeRowIdx > rowOverscanEndIdx) {
-      yield activeRowIdx;
-    }
-  }
-
   function getViewportRows() {
     const { idx: activeIdx, rowIdx: activeRowIdx } = activePosition;
 
-    return iterateOverViewportRowIdx()
+    return iterateOverViewportRowIdx(
+      activeRowIdx,
+      activePositionIsInViewport,
+      rowOverscanStartIdx,
+      rowOverscanEndIdx
+    )
       .map((rowIdx) => {
         const isActiveRow = rowIdx === activeRowIdx;
 
@@ -1323,4 +1313,21 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
 
 function isSamePosition(p1: Position, p2: Position) {
   return p1.idx === p2.idx && p1.rowIdx === p2.rowIdx;
+}
+
+function* iterateOverViewportRowIdx(
+  activeRowIdx: number,
+  activePositionIsInViewport: boolean,
+  rowOverscanStartIdx: number,
+  rowOverscanEndIdx: number
+) {
+  if (activePositionIsInViewport && activeRowIdx < rowOverscanStartIdx) {
+    yield activeRowIdx;
+  }
+  for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
+    yield rowIdx;
+  }
+  if (activePositionIsInViewport && activeRowIdx > rowOverscanEndIdx) {
+    yield activeRowIdx;
+  }
 }

--- a/src/EditCell.tsx
+++ b/src/EditCell.tsx
@@ -63,12 +63,24 @@ export default function EditCell<R, SR>({
   const frameRequestRef = useRef<number>(undefined);
   const commitOnOutsideClick = column.editorOptions?.commitOnOutsideClick ?? true;
 
+  function onClose(commitChanges = false, shouldFocus = true) {
+    if (commitChanges) {
+      onRowChange(row, true, shouldFocus);
+    } else {
+      closeEditor(shouldFocus);
+    }
+  }
+
   // We need to prevent the `useLayoutEffect` from cleaning up between re-renders,
   // as `onWindowCaptureMouseDown` might otherwise miss valid mousedown events.
   // To that end we instead access the latest props via useEffectEvent.
   const commitOnOutsideMouseDown = useEffectEvent(() => {
     onClose(true, false);
   });
+
+  function handleMouseDownCapture() {
+    cancelTask(captureEventRef, abortControllerRef, frameRequestRef);
+  }
 
   useLayoutEffect(() => {
     if (!commitOnOutsideClick) return;
@@ -106,23 +118,9 @@ export default function EditCell<R, SR>({
     return () => {
       globalThis.removeEventListener('mousedown', onWindowCaptureMouseDown, { capture: true });
       globalThis.removeEventListener('mousedown', onWindowMouseDown);
-      cancelTask();
+      cancelTask(captureEventRef, abortControllerRef, frameRequestRef);
     };
   }, [commitOnOutsideClick]);
-
-  // TODO: report react compiler bug
-  // oxlint-disable-next-line react/invariant
-  function cancelTask() {
-    captureEventRef.current = undefined;
-    if (abortControllerRef.current !== undefined) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = undefined;
-    }
-    if (frameRequestRef.current !== undefined) {
-      cancelAnimationFrame(frameRequestRef.current);
-      frameRequestRef.current = undefined;
-    }
-  }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (onKeyDown) {
@@ -153,14 +151,6 @@ export default function EditCell<R, SR>({
     }
   }
 
-  function onClose(commitChanges = false, shouldFocus = true) {
-    if (commitChanges) {
-      onRowChange(row, true, shouldFocus);
-    } else {
-      closeEditor(shouldFocus);
-    }
-  }
-
   function onEditorRowChange(row: R, commitChangesAndFocus = false) {
     onRowChange(row, commitChangesAndFocus, commitChangesAndFocus);
   }
@@ -182,7 +172,7 @@ export default function EditCell<R, SR>({
       className={className}
       style={getCellStyle(column, colSpan)}
       onKeyDown={handleKeyDown}
-      onMouseDownCapture={cancelTask}
+      onMouseDownCapture={handleMouseDownCapture}
     >
       {column.renderEditCell != null && (
         <>
@@ -206,4 +196,20 @@ export default function EditCell<R, SR>({
       )}
     </div>
   );
+}
+
+function cancelTask(
+  captureEventRef: React.RefObject<MouseEvent | undefined>,
+  abortControllerRef: React.RefObject<AbortController | undefined>,
+  frameRequestRef: React.RefObject<number | undefined>
+) {
+  captureEventRef.current = undefined;
+  if (abortControllerRef.current !== undefined) {
+    abortControllerRef.current.abort();
+    abortControllerRef.current = undefined;
+  }
+  if (frameRequestRef.current !== undefined) {
+    cancelAnimationFrame(frameRequestRef.current);
+    frameRequestRef.current = undefined;
+  }
 }

--- a/src/GroupRow.tsx
+++ b/src/GroupRow.tsx
@@ -46,8 +46,10 @@ function GroupedRow<R, SR>({
   ...props
 }: GroupRowRendererProps<R, SR>) {
   const isPositionOnRow = activeCellIdx === -1;
-
-  let idx = row.level;
+  const viewportColumns = iterateOverViewportColumnsForRow(activeCellIdx).toArray();
+  // the select column, when rendered, is always the first column
+  const groupColumnIndex =
+    viewportColumns[0]?.[0].key === SELECT_COLUMN_KEY ? row.level + 1 : row.level;
 
   function handleSelectGroup() {
     setActivePosition({ rowIdx, idx: -1 }, { shouldFocus: true });
@@ -78,31 +80,21 @@ function GroupedRow<R, SR>({
         style={{ gridRowStart }}
         {...props}
       >
-        {iterateOverViewportColumnsForRow(activeCellIdx)
-          .map(([column, isCellActive], index) => {
-            // Select is always the first column
-            if (index === 0 && column.key === SELECT_COLUMN_KEY) {
-              // oxlint-disable-next-line react/immutability
-              idx += 1;
-            }
-
-            return (
-              <GroupCell
-                key={column.key}
-                id={row.id}
-                groupKey={row.groupKey}
-                childRows={row.childRows}
-                isExpanded={row.isExpanded}
-                isCellActive={isCellActive}
-                column={column}
-                row={row}
-                groupColumnIndex={idx}
-                toggleGroup={toggleGroup}
-                isGroupByColumn={groupBy.includes(column.key)}
-              />
-            );
-          })
-          .toArray()}
+        {viewportColumns.map(([column, isCellActive]) => (
+          <GroupCell
+            key={column.key}
+            id={row.id}
+            groupKey={row.groupKey}
+            childRows={row.childRows}
+            isExpanded={row.isExpanded}
+            isCellActive={isCellActive}
+            column={column}
+            row={row}
+            groupColumnIndex={groupColumnIndex}
+            toggleGroup={toggleGroup}
+            isGroupByColumn={groupBy.includes(column.key)}
+          />
+        ))}
       </div>
     </RowSelectionContext>
   );

--- a/src/TreeDataGrid.tsx
+++ b/src/TreeDataGrid.tsx
@@ -143,6 +143,11 @@ export function TreeDataGrid<R, SR = unknown, K extends Key = Key>({
     (row: R | GroupRow<R>) => row is GroupRow<R>
   ] => {
     const allGroupRows = new Set<unknown>();
+
+    function isGroupRow(row: R | GroupRow<R>): row is GroupRow<R> {
+      return allGroupRows.has(row);
+    }
+
     if (!groupedRows) return [rawRows, isGroupRow];
 
     const flattenedRows: (R | GroupRow<R>)[] = [];
@@ -186,10 +191,6 @@ export function TreeDataGrid<R, SR = unknown, K extends Key = Key>({
 
     expandGroup(groupedRows, undefined, 0);
     return [flattenedRows, isGroupRow];
-
-    function isGroupRow(row: R | GroupRow<R>): row is GroupRow<R> {
-      return allGroupRows.has(row);
-    }
   }, [expandedGroupIds, groupedRows, rawRows, groupIdGetter]);
 
   const rowHeight = useMemo(() => {

--- a/src/hooks/useCalculatedColumns.ts
+++ b/src/hooks/useCalculatedColumns.ts
@@ -122,7 +122,7 @@ export function useCalculatedColumns<R, SR>({
         columns.push(column);
 
         if (isStartFrozen(frozen)) {
-          lastStartFrozenColumnIndex++;
+          lastStartFrozenColumnIndex += 1;
         }
 
         if (level > headerRowsCount) {

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -65,7 +65,9 @@ export function useColumnWidths<R, SR>(
 
     for (const key of columnsToMeasure) {
       const measuredWidth = measureColumnWidth(gridRef, key);
-      hasChanges ||= measuredWidth !== columnWidths.get(key)?.width;
+      if (measuredWidth !== columnWidths.get(key)?.width) {
+        hasChanges = true;
+      }
       if (measuredWidth === undefined) {
         newColumnWidths.delete(key);
       } else {

--- a/src/hooks/useViewportColumns.ts
+++ b/src/hooks/useViewportColumns.ts
@@ -41,36 +41,18 @@ export function useViewportColumns<R, SR>({
   const startIdx = useMemo(() => {
     if (colOverscanStartIdx === 0) return 0;
 
-    function* iterateOverRowsForColSpanArgs(): Generator<ColSpanArgs<R, SR>> {
-      // check header row
-      yield { type: 'HEADER' };
-
-      // check top summary rows
-      if (topSummaryRows != null) {
-        for (const row of topSummaryRows) {
-          yield { type: 'SUMMARY', row };
-        }
-      }
-
-      // check viewport rows
-      for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
-        yield { type: 'ROW', row: rows[rowIdx] };
-      }
-
-      // check bottom summary rows
-      if (bottomSummaryRows != null) {
-        for (const row of bottomSummaryRows) {
-          yield { type: 'SUMMARY', row };
-        }
-      }
-    }
-
     for (const column of colSpanColumns) {
       if (column.frozen) continue;
       const colIdx = column.idx;
       if (colIdx >= colOverscanStartIdx) break;
 
-      for (const args of iterateOverRowsForColSpanArgs()) {
+      for (const args of iterateOverRowsForColSpanArgs<R, SR>(
+        rows,
+        topSummaryRows,
+        bottomSummaryRows,
+        rowOverscanStartIdx,
+        rowOverscanEndIdx
+      )) {
         const colSpan = getColSpan(
           column,
           lastStartFrozenColumnIndex,
@@ -88,7 +70,6 @@ export function useViewportColumns<R, SR>({
   }, [
     rowOverscanStartIdx,
     rowOverscanEndIdx,
-    // oxlint-disable-next-line react/memo-dependencies
     rows,
     topSummaryRows,
     bottomSummaryRows,
@@ -106,35 +87,15 @@ export function useViewportColumns<R, SR>({
       : colOverscanEndIdx;
 
   const iterateOverViewportColumns = useCallback<IterateOverViewportColumns<R, SR>>(
-    function* (activeColumnIdx): Generator<CalculatedColumn<R, SR>> {
-      for (let colIdx = 0; colIdx <= lastStartFrozenColumnIndex; colIdx++) {
-        yield columns[colIdx];
-      }
-
-      const unfrozenLastIdx =
-        firstEndFrozenColumnIndex > -1 ? firstEndFrozenColumnIndex - 1 : columns.length - 1;
-
-      if (lastStartFrozenColumnIndex < unfrozenLastIdx) {
-        if (activeColumnIdx > lastStartFrozenColumnIndex && activeColumnIdx < startIdx) {
-          yield columns[activeColumnIdx];
-        }
-
-        for (let colIdx = startIdx; colIdx <= effectiveOverscanEndIdx; colIdx++) {
-          yield columns[colIdx];
-        }
-
-        if (activeColumnIdx > effectiveOverscanEndIdx && activeColumnIdx <= unfrozenLastIdx) {
-          yield columns[activeColumnIdx];
-        }
-      }
-
-      // Always yield end-frozen tail (virtualization must keep these in the DOM)
-      if (firstEndFrozenColumnIndex > -1) {
-        for (let colIdx = firstEndFrozenColumnIndex; colIdx < columns.length; colIdx++) {
-          yield columns[colIdx];
-        }
-      }
-    },
+    (activeColumnIdx) =>
+      iterateOverColumns(
+        columns,
+        lastStartFrozenColumnIndex,
+        firstEndFrozenColumnIndex,
+        startIdx,
+        effectiveOverscanEndIdx,
+        activeColumnIdx
+      ),
     [
       startIdx,
       effectiveOverscanEndIdx,
@@ -145,39 +106,28 @@ export function useViewportColumns<R, SR>({
   );
 
   const iterateOverViewportColumnsForRow = useCallback<IterateOverViewportColumnsForRow<R, SR>>(
-    function* (activeColumnIdx = -1, args): Generator<ViewportColumnWithColSpan<R, SR>> {
-      const iterator = iterateOverViewportColumns(activeColumnIdx);
-
-      for (const column of iterator) {
-        let colSpan =
-          args && getColSpan(column, lastStartFrozenColumnIndex, firstEndFrozenColumnIndex, args);
-
-        yield [column, column.idx === activeColumnIdx, colSpan];
-
-        // skip columns covered by colSpan
-        while (colSpan !== undefined && colSpan > 1) {
-          iterator.next();
-          colSpan--;
-        }
-      }
-    },
+    (activeColumnIdx = -1, args) =>
+      iterateOverColumnsForRow(
+        iterateOverViewportColumns(activeColumnIdx),
+        activeColumnIdx,
+        lastStartFrozenColumnIndex,
+        firstEndFrozenColumnIndex,
+        args
+      ),
     [iterateOverViewportColumns, lastStartFrozenColumnIndex, firstEndFrozenColumnIndex]
   );
 
   const iterateOverViewportColumnsForRowOutsideOfViewport = useCallback<
     IterateOverViewportColumnsForRow<R, SR>
   >(
-    function* (activeColumnIdx = -1, args): Generator<ViewportColumnWithColSpan<R, SR>> {
-      if (activeColumnIdx >= 0 && activeColumnIdx < columns.length) {
-        const column = columns[activeColumnIdx];
-        yield [
-          column,
-          true,
-          args && getColSpan(column, lastStartFrozenColumnIndex, firstEndFrozenColumnIndex, args)
-        ];
-      }
-    },
-    // oxlint-disable-next-line react/memo-dependencies
+    (activeColumnIdx = -1, args) =>
+      iterateOverColumnForRowOutsideOfViewport(
+        columns,
+        lastStartFrozenColumnIndex,
+        firstEndFrozenColumnIndex,
+        activeColumnIdx,
+        args
+      ),
     [columns, lastStartFrozenColumnIndex, firstEndFrozenColumnIndex]
   );
 
@@ -190,4 +140,109 @@ export function useViewportColumns<R, SR>({
     iterateOverViewportColumnsForRow,
     iterateOverViewportColumnsForRowOutsideOfViewport
   } as const;
+}
+
+function* iterateOverRowsForColSpanArgs<R, SR>(
+  rows: readonly R[],
+  topSummaryRows: Maybe<readonly SR[]>,
+  bottomSummaryRows: Maybe<readonly SR[]>,
+  rowOverscanStartIdx: number,
+  rowOverscanEndIdx: number
+): Generator<ColSpanArgs<R, SR>> {
+  // check header row
+  yield { type: 'HEADER' };
+
+  // check top summary rows
+  if (topSummaryRows != null) {
+    for (const row of topSummaryRows) {
+      yield { type: 'SUMMARY', row };
+    }
+  }
+
+  // check viewport rows
+  for (let rowIdx = rowOverscanStartIdx; rowIdx <= rowOverscanEndIdx; rowIdx++) {
+    yield { type: 'ROW', row: rows[rowIdx] };
+  }
+
+  // check bottom summary rows
+  if (bottomSummaryRows != null) {
+    for (const row of bottomSummaryRows) {
+      yield { type: 'SUMMARY', row };
+    }
+  }
+}
+
+function* iterateOverColumns<R, SR>(
+  columns: readonly CalculatedColumn<R, SR>[],
+  lastStartFrozenColumnIndex: number,
+  firstEndFrozenColumnIndex: number,
+  startIdx: number,
+  effectiveOverscanEndIdx: number,
+  activeColumnIdx: number
+): Generator<CalculatedColumn<R, SR>> {
+  for (let colIdx = 0; colIdx <= lastStartFrozenColumnIndex; colIdx++) {
+    yield columns[colIdx];
+  }
+
+  const unfrozenLastIdx =
+    firstEndFrozenColumnIndex > -1 ? firstEndFrozenColumnIndex - 1 : columns.length - 1;
+
+  if (lastStartFrozenColumnIndex < unfrozenLastIdx) {
+    if (activeColumnIdx > lastStartFrozenColumnIndex && activeColumnIdx < startIdx) {
+      yield columns[activeColumnIdx];
+    }
+
+    for (let colIdx = startIdx; colIdx <= effectiveOverscanEndIdx; colIdx++) {
+      yield columns[colIdx];
+    }
+
+    if (activeColumnIdx > effectiveOverscanEndIdx && activeColumnIdx <= unfrozenLastIdx) {
+      yield columns[activeColumnIdx];
+    }
+  }
+
+  // Always yield end-frozen tail (virtualization must keep these in the DOM)
+  if (firstEndFrozenColumnIndex > -1) {
+    for (let colIdx = firstEndFrozenColumnIndex; colIdx < columns.length; colIdx++) {
+      yield columns[colIdx];
+    }
+  }
+}
+
+function* iterateOverColumnsForRow<R, SR>(
+  iterator: IteratorObject<CalculatedColumn<R, SR>>,
+  activeColumnIdx: number,
+  lastStartFrozenColumnIndex: number,
+  firstEndFrozenColumnIndex: number,
+  args: ColSpanArgs<R, SR> | undefined
+): Generator<ViewportColumnWithColSpan<R, SR>> {
+  for (const column of iterator) {
+    let colSpan =
+      args && getColSpan(column, lastStartFrozenColumnIndex, firstEndFrozenColumnIndex, args);
+
+    yield [column, column.idx === activeColumnIdx, colSpan];
+
+    // skip columns covered by colSpan
+    while (colSpan !== undefined && colSpan > 1) {
+      iterator.next();
+      colSpan--;
+    }
+  }
+}
+
+function* iterateOverColumnForRowOutsideOfViewport<R, SR>(
+  columns: readonly CalculatedColumn<R, SR>[],
+  lastStartFrozenColumnIndex: number,
+  firstEndFrozenColumnIndex: number,
+  activeColumnIdx: number,
+  args: ColSpanArgs<R, SR> | undefined
+): Generator<ViewportColumnWithColSpan<R, SR>> {
+  if (activeColumnIdx >= 0 && activeColumnIdx < columns.length) {
+    const column = columns[activeColumnIdx];
+    yield [
+      column,
+      true,
+      args && getColSpan(column, lastStartFrozenColumnIndex, firstEndFrozenColumnIndex, args)
+    ];
+  }
 }

--- a/src/hooks/useViewportRows.ts
+++ b/src/hooks/useViewportRows.ts
@@ -50,7 +50,7 @@ export function useViewportRows<R>({
         repeatCount = 1;
       } else if (currentHeight === currentRowHeight) {
         // If the current row height is the same as the previous one, increment the repeat count
-        repeatCount++;
+        repeatCount += 1;
       } else {
         if (repeatCount > 1) {
           gridTemplateRows += `repeat(${repeatCount}, ${currentHeight}px) `;


### PR DESCRIPTION
Stacked on top of #4161.

`tsdown` now logs 21 React Compiler diagnostics, each one causing the compiler to skip optimizing the enclosing component or hook. After this PR the build is silent.

### Unsupported syntax (`Todo`)

- **`useColumnWidths`** — replace `||=` with an `if` statement. Note that `hasChanges = hasChanges || …` would trip `eslint/logical-assignment-operators`.
- **`useCalculatedColumns`** / **`useViewportRows`** — replace `x++` on variables captured within lambdas with `x += 1`.
- **`useViewportColumns`** (11 diagnostics) / **`DataGrid`** (3) — generators cannot be lowered at all, so every `function*` is hoisted out of the hook/component body to module scope, taking what it used to close over as parameters. The `useCallback`s now simply return the generator object. Two `react/memo-dependencies` suppressions became unused — the compiler had been bailing on the whole file — and are dropped.

### Immutability

- **`GroupRow`** — `let idx` was mutated inside the render `.map()`. The increment only ever depended on whether the first rendered column is the select column, so the columns are materialized once and `groupColumnIndex` is computed as a constant before the JSX.
- **`DataGrid`** — `setPosition` was read by `useImperativeHandle`/`useLatestFunc` before its declaration; the declaration moves above the `Misc hooks` block. Pure code motion.

### Invariant

- **`EditCell`** — `cancelTask` was a hoisted function referenced by an effect declared above it. It is extracted to module scope taking the three refs, which keeps the effect's `[commitOnOutsideClick]` dependency list correct: adding a component-body `cancelTask` as a dependency would make the effect tear down between re-renders, which the comment there explicitly guards against. `onClose` also moves above the `useEffectEvent` that calls it. The `TODO: report react compiler bug` note and its suppression are gone.

### Unreachable hoisted declaration

- **`TreeDataGrid`** — `isGroupRow` was declared after a `return`; moved above the early return.

### Notes

The `DataGrid` and `EditCell` fixes are sensitive to *ordering* within the component body rather than to any real defect, so a future compiler version may make some of these moves unnecessary.

`lint`, `format`, `typecheck` and the full test suite (529 passed, 3 skipped) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NZmYxgysVEbw12FnbAf7x