### PR TITLE
ecij@0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@vitest/browser-playwright": "^4.1.5",
         "@vitest/coverage-istanbul": "^4.1.5",
         "clsx": "^2.1.1",
-        "ecij": "^0.4.1",
+        "ecij": "^0.5.0",
         "eslint": "^10.2.1",
         "jspdf": "^4.2.0",
         "jspdf-autotable": "^5.0.7",
@@ -3433,11 +3433,20 @@
       }
     },
     "node_modules/ecij": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/ecij/-/ecij-0.4.1.tgz",
-      "integrity": "sha512-s0Tf5YixZI06oLiB6aQ/t2t+Oeul4ixD0qu7Xi//umChQxRXJGPdCf16jUgATewtVn7I+7CbOqj63NpM5/PHcg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ecij/-/ecij-0.5.0.tgz",
+      "integrity": "sha512-g4yPRbb7EWwD8CfPcx20bHd6sTljXp61CDe4V6kg8APs5NAG2ajxR9+dIIYzI83B745CGqK8wP45c3BB59PW3Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "rolldown": "^1.2.0",
+        "vite": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.412",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@vitest/browser-playwright": "^4.1.5",
     "@vitest/coverage-istanbul": "^4.1.5",
     "clsx": "^2.1.1",
-    "ecij": "^0.4.1",
+    "ecij": "^0.5.0",
     "eslint": "^10.2.1",
     "jspdf": "^4.2.0",
     "jspdf-autotable": "^5.0.7",


### PR DESCRIPTION
No output changes in the lib/website, except that sourcemaps work now

https://github.com/nstepien/ecij/releases/tag/v0.5.0