### PR TITLE
Remove tsgolint path settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,10 +10,6 @@
   // ESLint is only used for markdown; JS/TS is linted by the oxc extension
   "eslint.validate": ["markdown"],
   "eslint.problems.shortenToSingleLine": true,
-  "oxc.path.tsgolint": "node_modules/.bin/tsgolint.cmd",
-  "terminal.integrated.env.windows": {
-    "OXLINT_TSGOLINT_PATH": "node_modules/.bin/tsgolint.cmd"
-  },
   "files.readonlyInclude": {
     "**/routeTree.gen.ts": true
   },


### PR DESCRIPTION
We probably don't need to keep these, pretty sure I'm the only one affected because of my environment
https://github.com/oxc-project/oxc/pull/26234

Please check locally