### PR TITLE
vite: re-enable chunkImportMap

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,10 +63,17 @@ export default defineConfig(({ isPreview }): ViteUserConfig => ({
   cacheDir: 'node_modules/.cache/vite',
   clearScreen: false,
   build: {
-    // chunkImportMap: true,
+    chunkImportMap: true,
     modulePreload: { polyfill: false },
     sourcemap: true,
     rolldownOptions: {
+      // TODO: remove
+      // https://github.com/vitejs/vite/issues/23350
+      experimental: {
+        chunkImportMap: {
+          baseUrl: '/react-data-grid/'
+        }
+      },
       output: {
         codeSplitting: {
           groups: [


### PR DESCRIPTION
We can remove the experimental config once https://github.com/vitejs/vite/issues/23350 is fixed